### PR TITLE
refactor: Beaker transformer test to use dictionary

### DIFF
--- a/tests/unit/test_beaker_transformer.py
+++ b/tests/unit/test_beaker_transformer.py
@@ -114,67 +114,81 @@ class TestBeakerTransformer:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "meta_host,exp_distro,exp_variant,exp_ks_meta,exp_ks_append,exp_whiteboard,exp_prio",  # noqa: E501
+        "meta_host, exp_values",  # noqa: E501
         [
             (
                 fedora,
-                "Fedora-36%",
-                "Server",
-                "FEDORA_HOST_KS_META",
-                default_ks_append,
-                default_whiteboard,
-                default_prio,
+                {
+                    "distro": "Fedora-36%",
+                    "variant": "Server",
+                    "ks_meta": "FEDORA_HOST_KS_META",
+                    "ks_append": default_ks_append,
+                    "whiteboard": default_whiteboard,
+                    "priority": default_prio,
+                },
             ),
             (
                 centos,
-                "CentOS-Stream-9%",
-                "BaseOS",
-                "PROV_CONF_CENTOS_KS_META",
-                ["%post\ncat /etc/redhat-release\n%end"],
-                default_whiteboard,
-                default_prio,
+                {
+                    "distro": "CentOS-Stream-9%",
+                    "variant": "BaseOS",
+                    "ks_meta": "PROV_CONF_CENTOS_KS_META",
+                    "ks_append": ["%post\ncat /etc/redhat-release\n%end"],
+                    "whiteboard": default_whiteboard,
+                    "priority": default_prio,
+                },
             ),
             # default variant should be there,
             # windows distro does not exist so host['os'] should be copied
             (
                 windows,
-                "win-2022",
-                "BaseOS",
-                "PROV_CONF_DEFAULT",
-                default_ks_append,
-                "BEAKER DOES NOT SUPPORT WINDOWS THIS JOB MUST FAIL",
-                "ULTRAHIGH",
+                {
+                    "distro": "win-2022",
+                    "variant": "BaseOS",
+                    "ks_meta": "PROV_CONF_DEFAULT",
+                    "ks_append": default_ks_append,
+                    "whiteboard": "BEAKER DOES NOT SUPPORT WINDOWS THIS JOB MUST FAIL",
+                    "priority": "ULTRAHIGH",
+                },
             ),
             (
                 rhel86,
-                "RHEL-8.6%",
-                "BaseOS",
-                "PROV_CONF_RHEL86_KS_META",
-                ["%post\ncat /etc/redhat-release\nwget redhat.com\n%end"],
-                default_whiteboard,
-                default_prio,
+                {
+                    "distro": "RHEL-8.6%",
+                    "variant": "BaseOS",
+                    "ks_meta": "PROV_CONF_RHEL86_KS_META",
+                    "ks_append": [
+                        "%post\ncat /etc/redhat-release\nwget redhat.com\n%end"
+                    ],
+                    "whiteboard": default_whiteboard,
+                    "priority": default_prio,
+                },
             ),
         ],
     )
     async def test_beaker_requirement(
         self,
         meta_host,
-        exp_distro,
-        exp_variant,
-        exp_ks_meta,
-        exp_ks_append,
-        exp_whiteboard,
-        exp_prio,
+        exp_values,
     ):
         """Test expected Beaker VM variant and distro"""
+        beaker_req_keys = [
+            "distro",
+            "variant",
+            "ks_meta",
+            "ks_append",
+            "whiteboard",
+            "priority",
+            "task",
+        ]
         bkr_transformer = await self.create_transformer()
         req = bkr_transformer.create_host_requirement(meta_host)
-        assert req.get("distro") == exp_distro
-        assert req.get("variant") == exp_variant
-        assert req.get("ks_meta") == exp_ks_meta
-        assert req.get("ks_append") == exp_ks_append
-        assert req.get("whiteboard") == exp_whiteboard
-        assert req.get("priority") == exp_prio
+        for key in beaker_req_keys:
+            err = (
+                f"Mismatch of transformed value and expected value[{key}]: "
+                f"{req.get(key)} != {exp_values.get(key)}"
+            )
+            assert req.get(key) == exp_values.get(key), err
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(


### PR DESCRIPTION
Refactor beaker transformer test to use dictionary instead of multiple parameters in function call. This increase readability of test.